### PR TITLE
When deleting a group from the group health view, the user is redirec…

### DIFF
--- a/src/Controllers/GroupController.php
+++ b/src/Controllers/GroupController.php
@@ -528,7 +528,7 @@ class GroupController
             return redirect( route_url( "?e=" . $result->get_error_message() ) );
         }
 
-        return redirect( route_url() );
+        return redirect( route_url( 'groups' ) );
     }
 
     /**


### PR DESCRIPTION
…t to the genmap, but they should be redirected back to the health view